### PR TITLE
Match font attributes

### DIFF
--- a/source/OpenSans-Italic.glyphs
+++ b/source/OpenSans-Italic.glyphs
@@ -267598,6 +267598,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 instanceInterpolations = {
@@ -267624,6 +267656,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationWeight = 170;
@@ -267650,6 +267714,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationWeight = 237;
@@ -267679,6 +267775,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationWeight = 310;
@@ -267707,6 +267835,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationWeight = 396;
@@ -267735,6 +267895,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationCustom = 100;
@@ -267764,6 +267956,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationWeight = 170;
@@ -267793,6 +268017,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationWeight = 239;
@@ -267824,6 +268080,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationWeight = 310;
@@ -267855,6 +268143,38 @@ value = (
 2,
 4
 );
+},
+{
+name = subscriptYOffset;
+value = "287";
+},
+{
+name = superscriptYSize;
+value = "1331";
+},
+{
+name = superscriptXSize;
+value = "1434";
+},
+{
+name = superscriptYOffset;
+value = "977";
+},
+{
+name = subscriptXSize;
+value = "1434";
+},
+{
+name = subscriptYSize;
+value = "1331";
+},
+{
+name = strikeoutPosition;
+value = 497;
+},
+{
+name = subscriptYOffset;
+value = "0";
 }
 );
 interpolationCustom = 400;

--- a/source/OpenSans-Italic.glyphs
+++ b/source/OpenSans-Italic.glyphs
@@ -267583,6 +267583,23 @@ rightKerningGroup = NULL;
 );
 instances = (
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 instanceInterpolations = {
 "4C802D5D-2BAD-4759-8C93-835BB7B64EA1" = 1;
 };
@@ -267592,6 +267609,23 @@ name = "Light Italic";
 weightClass = Light;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationWeight = 170;
 instanceInterpolations = {
 "0B5E954E-D3E5-4A16-AD17-8B1BCB8BDBD4" = 0.23333;
@@ -267601,6 +267635,23 @@ isItalic = 1;
 name = Italic;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationWeight = 237;
 instanceInterpolations = {
 "0B5E954E-D3E5-4A16-AD17-8B1BCB8BDBD4" = 0.45667;
@@ -267613,6 +267664,23 @@ name = "SemiBold Italic";
 weightClass = SemiBold;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationWeight = 310;
 instanceInterpolations = {
 "0B5E954E-D3E5-4A16-AD17-8B1BCB8BDBD4" = 0.7;
@@ -267624,6 +267692,23 @@ name = "Bold Italic";
 weightClass = Bold;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationWeight = 396;
 instanceInterpolations = {
 "0B5E954E-D3E5-4A16-AD17-8B1BCB8BDBD4" = 0.98667;
@@ -267635,6 +267720,23 @@ name = "ExtraBold Italic";
 weightClass = ExtraBold;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationCustom = 100;
 interpolationWidth = 75;
 instanceInterpolations = {
@@ -267647,6 +267749,23 @@ weightClass = Light;
 widthClass = Condensed;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationWeight = 170;
 interpolationWidth = 75;
 instanceInterpolations = {
@@ -267659,6 +267778,23 @@ name = "Condensed Italic";
 widthClass = Condensed;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationWeight = 239;
 interpolationWidth = 75;
 instanceInterpolations = {
@@ -267673,6 +267809,23 @@ weightClass = SemiBold;
 widthClass = Condensed;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationWeight = 310;
 interpolationWidth = 75;
 instanceInterpolations = {
@@ -267687,6 +267840,23 @@ weightClass = Bold;
 widthClass = Condensed;
 },
 {
+customParameters = (
+{
+name = panose;
+value = (
+2,
+11,
+6,
+6,
+3,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
 interpolationCustom = 400;
 interpolationWeight = 400;
 interpolationWidth = 75;


### PR DESCRIPTION
I've set the panose, subscript and superscript attributes so they match the fonts we currently serve on Google Fonts. Atm, these are not exported properly in the VF. This may be a fontmake issue or problem with our build setup. I'll investigate if this is our fault now.